### PR TITLE
Add new version for kubernetes v1.13.1 and relative plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+
+源仓库[mritd/docker-library] (https://github.com/mritd/docker-library)已经停止维护，开始采用新的同步工具自动完成构建，可移步 [mritd/gcr](https://github.com/mritd/gcr)
+
 # docker-library
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED
 
-源仓库[mritd/docker-library] (https://github.com/mritd/docker-library)已经停止维护，开始采用新的同步工具自动完成构建，可移步 [mritd/gcr](https://github.com/mritd/gcr)
+源仓库[mritd/docker-library] (https://github.com/mritd/docker-library) 已经停止维护，开始采用新的同步工具自动完成构建，可移步 [mritd/gcr](https://github.com/mritd/gcr)
 
 # docker-library
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED
 
-源仓库[mritd/docker-library] (https://github.com/mritd/docker-library)已经停止维护，开始采用新的同步工具自动完成构建，可移步 [mritd/gcr](https://github.com/mritd/gcr)
+源仓库[mritd/docker-library](https://github.com/mritd/docker-library) 已经停止维护，开始采用新的同步工具自动完成构建，可移步 [mritd/gcr](https://github.com/mritd/gcr)
 
 # docker-library
 

--- a/coredns/1.2.6/Dockerfile
+++ b/coredns/1.2.6/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_containers/coredns:1.2.6
+MAINTAINER schua <schua1015@hotmail.com>

--- a/etcd-amd64/3.2.24/Dockerfile
+++ b/etcd-amd64/3.2.24/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_containers/etcd-amd64:3.2.24
+MAINTAINER schua <schua1015@hotmail.com>

--- a/kube-apiserver-amd64/v1.13.1/Dockerfile
+++ b/kube-apiserver-amd64/v1.13.1/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_containers/kube-apiserver-amd64:v1.13.1
+MAINTAINER schua <schua1015@hotmail.com>

--- a/kube-controller-manager-amd64/v1.13.1/Dockerfile
+++ b/kube-controller-manager-amd64/v1.13.1/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_containers/kube-controller-manager-amd64:v1.13.1
+MAINTAINER schua <schua1015@hotmail.com>

--- a/kube-proxy-amd64/v1.13.1/Dockerfile
+++ b/kube-proxy-amd64/v1.13.1/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_containers/kube-proxy-amd64:v1.13.1
+MAINTAINER schua <schua1015@hotmail.com>

--- a/kube-scheduler-amd64/v1.13.1/Dockerfile
+++ b/kube-scheduler-amd64/v1.13.1/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_containers/kube-scheduler-amd64:v1.13.1
+MAINTAINER schua <schua1015@hotmail.com>

--- a/kubernetes-dashboard-amd64/v1.10.1/Dockerfile
+++ b/kubernetes-dashboard-amd64/v1.10.1/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_containers/kubernetes-dashboard-amd64:v1.10.1
+MAINTAINER schua <schua1015@hotmail.com>

--- a/tiller/v2.12.1/Dockerfile
+++ b/tiller/v2.12.1/Dockerfile
@@ -1,1 +1,1 @@
-FROM gcr.io/google_containers/tiller:v2.12.1
+FROM gcr.io/kubernetes-helm/tiller:v2.12.1

--- a/tiller/v2.12.1/Dockerfile
+++ b/tiller/v2.12.1/Dockerfile
@@ -1,0 +1,1 @@
+FROM gcr.io/google_containers/tiller:v2.12.1


### PR DESCRIPTION
Add v1.13.1 for kube-apiserver, kube-controller-mananger, kube-scheduler and kube-proxy, 3.2.24 for etcd, 1.2.6 for coredns and 1.10.1 for kubernetes-dashboard.